### PR TITLE
docs(team_project): add team workspace with project plan and architec…

### DIFF
--- a/team_project/README.md
+++ b/team_project/README.md
@@ -1,0 +1,31 @@
+# Milestone Mavericks — Team Workspace
+
+## Team
+
+| Name | Role |
+|------|------|
+| Sohail Anwar | Scrum Master |
+| Poorani T S | Team Member |
+| Sharan Saravanan | Team Member |
+
+## Course
+
+**CSS 566A — Software Management**
+University of Washington Bothell · Spring 2026
+Instructor: Prof. Mia Champion
+
+## Project Scope
+
+We are building an **AI-assisted DAG failure triage plugin** for Apache Airflow.
+The plugin ingests task-instance logs from a failing DAG run, classifies the
+failure using a lightweight heuristic layer followed by an LLM summarization
+layer, and surfaces ranked remediation candidates to the on-call engineer.
+A local-only execution mode ensures the plugin can run without sending log data
+to an external API, satisfying data-residency requirements.
+
+## Links
+
+| Resource | URL |
+|----------|-----|
+| Fork | https://github.com/break-through-19/airflow |
+| Kanban board | https://github.com/users/break-through-19/projects/9 |

--- a/team_project/docs/ARCHITECTURE.md
+++ b/team_project/docs/ARCHITECTURE.md
@@ -1,0 +1,105 @@
+# Architecture — AI-Assisted DAG Failure Triage Plugin
+
+## Overview
+
+The plugin is structured as four independent layers. Each layer has a single
+responsibility and communicates with adjacent layers through a stable interface.
+This satisfies the SOLID Single-Responsibility Principle and makes each layer
+independently testable, replaceable, and deployable.
+
+```
+Airflow task-instance logs
+        │
+        ▼
+┌─────────────────────────┐
+│  Log Normalization Layer │  Strips noise, emits FailureContext
+└────────────┬────────────┘
+             │ FailureContext
+             ▼
+┌─────────────────────────┐
+│  Heuristic Classifier   │  Returns ranked candidates
+└────────────┬────────────┘
+             │ RankedCandidates
+             ▼
+┌─────────────────────────┐
+│  LLM Summarization Layer│  Optional; skipped in local-only mode
+└────────────┬────────────┘
+             │ DiagnosisSummary
+             ▼
+┌─────────────────────────┐
+│  Remediation KB + UI    │  Displays runbooks alongside candidates
+└─────────────────────────┘
+```
+
+## Layer Descriptions
+
+### Log Normalization Layer
+
+**Responsibility:** Accept a raw Airflow task-instance log string and return a
+structured `FailureContext` dataclass.
+
+Strips ANSI escape codes, extracts the final exception type and message,
+identifies the stack-trace depth, and records metadata (task ID, DAG ID,
+try number, executor type). Downstream layers never touch raw log text.
+
+### Heuristic Classifier Layer
+
+**Responsibility:** Map a `FailureContext` to a ranked list of
+`FailureCandidate` objects, each carrying a category label and a confidence
+score.
+
+Rules are defined as an ordered priority list (e.g., check for
+`ModuleNotFoundError` before checking for `OperationalError`). The output is
+always a **ranked list**, never a single forced label. This is a deliberate
+design choice: when the top candidate's confidence is below a configurable
+threshold, the engineer sees multiple plausible categories and applies judgment
+rather than blindly following a single automated verdict.
+
+The classifier is entirely local — no network calls, no external dependencies
+beyond the standard library. It runs in local-only mode.
+
+### LLM Summarization Layer
+
+**Responsibility:** Accept the top-N ranked candidates and the normalized log
+excerpt and return a `DiagnosisSummary` with a human-readable explanation and
+suggested next steps.
+
+Sits behind a `Summarizer` protocol so it can be swapped for a different model
+or a stub without modifying the classifier or the UI surface. Disabled entirely
+when `triage.local_only = true` is set in `airflow.cfg`.
+
+### Remediation Knowledge Base and UI Surface
+
+**Responsibility:** Map a failure-category label to a remediation runbook and
+surface both the ranked candidates and the runbook to the on-call engineer.
+
+The KB is a version-controlled YAML file. Adding or updating a runbook is a
+content change, not a code change, so it can be merged without a full release
+cycle. The UI surface is a read-only Airflow plugin view — it does not mutate
+any Airflow database state.
+
+## Design Decisions
+
+### Why ranked candidates instead of a single label?
+
+Failure triage in distributed systems is rarely unambiguous. A
+`ConnectionResetError` can indicate a transient network blip, a misconfigured
+connection pool, or a downstream service outage — all requiring different
+remediation. Forcing a single label would either require an artificially high
+confidence threshold (leaving most failures unlabelled) or would mislead the
+engineer when the classifier is uncertain. Returning ranked candidates makes the
+classifier's uncertainty explicit and keeps the engineer in the loop.
+
+### Why a separate normalization layer?
+
+Both the classifier and the LLM layer need clean, structured input. Duplicating
+normalization logic inside each layer would couple them to raw log format
+changes. A single normalization layer means a log-format change is a one-place
+fix, and both downstream layers automatically benefit.
+
+### Why local-only mode?
+
+Many Airflow deployments run in environments with strict data-residency or
+air-gap requirements. Making local-only mode a first-class configuration option
+(not a fallback or a stripped-down build) ensures the plugin is adoptable in
+those environments from day one.

--- a/team_project/docs/PROJECT_PLAN.md
+++ b/team_project/docs/PROJECT_PLAN.md
@@ -1,0 +1,63 @@
+# Project Plan — AI-Assisted DAG Failure Triage Plugin
+
+## Outcome Metric
+
+Reduce the **median time-to-first-diagnosis** on a curated Airflow failure
+corpus — measured from the moment a DAG run transitions to `failed` to the
+moment the on-call engineer identifies the root-cause category.
+
+## Sprint Overview
+
+| Sprint | Goal | Key Deliverables |
+|--------|------|-----------------|
+| 1 | Foundation | Plugin scaffold, CI wiring, local dev environment |
+| 2 | Data layer | Log normalization pipeline, failure corpus, baseline metrics |
+| 3 | Classifier | Heuristic classifier with INVEST-validated acceptance tests |
+| 4 | LLM layer | LLM summarization integration, local-only mode |
+| 5 | Knowledge base | Remediation KB, ranked-candidate UI surface |
+| 6 | Hardening | End-to-end tests, performance profiling, docs, demo |
+
+## Deliverables
+
+### Plugin Scaffold
+A minimal, installable Airflow plugin package with entry-point registration,
+empty classifier and summarizer stubs, and a passing CI pipeline. Establishes
+the SOLID single-responsibility boundary between layers from day one.
+
+### Log Normalization
+A preprocessing stage that strips ANSI codes, trims stack-trace noise, and
+emits a structured `FailureContext` dataclass consumed by both the classifier
+and the LLM layer. Keeps raw-log coupling out of higher layers.
+
+### Heuristic Classifier
+Rule-based first-pass classifier that maps `FailureContext` fields to ranked
+failure-category candidates (e.g., `dependency_missing`, `connection_timeout`,
+`oom`, `user_code_error`). Returns a ranked list, not a single label, so that
+engineer judgment is preserved when confidence is low.
+
+### LLM Summarization Layer
+Optional second-pass layer that feeds the top classifier candidates and the
+normalized log excerpt to a language model and returns a human-readable
+diagnosis summary and suggested next steps. Isolated behind an interface so it
+can be swapped or disabled without touching the classifier.
+
+### Remediation Knowledge Base
+A curated, version-controlled YAML knowledge base mapping failure categories to
+remediation runbooks. Consumed by the UI surface to display actionable guidance
+alongside the ranked candidates.
+
+### Local-Only Execution Mode
+A configuration flag (`triage.local_only = true`) that bypasses any external
+LLM API call and runs the heuristic classifier only. Ensures the plugin is
+usable in air-gapped or data-residency-constrained deployments.
+
+## Frameworks Applied
+
+| Framework | How We Apply It |
+|-----------|----------------|
+| **Scrum** | Two-week sprints, daily stand-ups, sprint reviews with Prof. Champion |
+| **Working Backwards** | Outcome metric (time-to-first-diagnosis) defined before any code is written |
+| **INVEST** | Each user story is Independent, Negotiable, Valuable, Estimable, Small, Testable before sprint commitment |
+| **SOLID** | Each layer (normalization, classifier, summarizer, KB) is a separate class with a single responsibility and a stable interface |
+| **TDD** | Acceptance tests written from INVEST stories before implementation; classifier rules driven by failure corpus examples |
+| **Shift-Left** | Ruff, mypy, and ASYNC lint checks run on every commit; ASYNC110 class of violations caught before merge |


### PR DESCRIPTION
Adds a `team_project/` directory as a top-level workspace for the Milestone Mavericks team (CSS 566A, UW Bothell, Spring 2026, Prof. Mia Champion).

Three files added, no existing code modified:

- `team_project/README.md` — team members, course info, project scope, and links to the fork and Kanban board
- `team_project/docs/PROJECT_PLAN.md` — six-sprint plan, deliverables, outcome metric, and frameworks applied (Scrum, Working Backwards, INVEST, SOLID, TDD, shift-left)
- `team_project/docs/ARCHITECTURE.md` — four-layer plugin architecture with SOLID single-responsibility separation

---

