### PR TITLE
feat(team_project): add heuristic failure classifier with five-catego…

### DIFF
--- a/team_project/src/dag_triage/__init__.py
+++ b/team_project/src/dag_triage/__init__.py
@@ -1,0 +1,6 @@
+"""dag_triage — AI-assisted DAG failure triage plugin.
+
+Milestone Mavericks team, CSS 566A, UW Bothell, Spring 2026.
+"""
+
+__version__ = "0.1.0"

--- a/team_project/src/dag_triage/classifier.py
+++ b/team_project/src/dag_triage/classifier.py
@@ -1,0 +1,75 @@
+"""Heuristic failure classifier for Airflow task-instance logs."""
+
+from __future__ import annotations
+
+import re
+
+# Each entry is (compiled_pattern, confidence_weight).
+# Multiple matches in the same category accumulate; total is capped at 1.0.
+_RULES: dict[str, list[tuple[re.Pattern[str], float]]] = {
+    "TRANSIENT": [
+        (re.compile(r"timeout", re.IGNORECASE), 0.4),
+        (re.compile(r"connection\s+reset", re.IGNORECASE), 0.5),
+        (re.compile(r"\b503\b"), 0.4),
+        (re.compile(r"\b504\b"), 0.4),
+        (re.compile(r"retry\s+exhausted", re.IGNORECASE), 0.5),
+    ],
+    "DATA_QUALITY": [
+        (re.compile(r"null\s+value", re.IGNORECASE), 0.4),
+        (re.compile(r"schema\s+mismatch", re.IGNORECASE), 0.5),
+        (re.compile(r"validation\s+error", re.IGNORECASE), 0.4),
+        (re.compile(r"type\s+mismatch", re.IGNORECASE), 0.4),
+    ],
+    "RESOURCE": [
+        (re.compile(r"OutOfMemory", re.IGNORECASE), 0.5),
+        (re.compile(r"OOMKilled", re.IGNORECASE), 0.6),
+        (re.compile(r"disk\s+full", re.IGNORECASE), 0.5),
+        (re.compile(r"memory\s+limit", re.IGNORECASE), 0.4),
+    ],
+    "CODE": [
+        (re.compile(r"\bTypeError\b"), 0.4),
+        (re.compile(r"\bKeyError\b"), 0.4),
+        (re.compile(r"\bAttributeError\b"), 0.4),
+        (re.compile(r"\bNameError\b"), 0.4),
+        (re.compile(r"\bImportError\b"), 0.4),
+    ],
+    "EXTERNAL_DEPENDENCY": [
+        (re.compile(r"\bDNS\b", re.IGNORECASE), 0.4),
+        (re.compile(r"host\s+unreachable", re.IGNORECASE), 0.5),
+        (re.compile(r"certificate", re.IGNORECASE), 0.4),
+        (re.compile(r"\bSSL\b", re.IGNORECASE), 0.4),
+        (re.compile(r"\brefused\b", re.IGNORECASE), 0.3),
+    ],
+}
+
+
+class FailureClassifier:
+    """Classify an Airflow task-instance log into ranked failure categories.
+
+    Returns a ranked list of (category, confidence) tuples sorted by
+    confidence descending. Categories with zero signal are omitted.
+    A single label is never asserted; callers should inspect the full
+    ranked list and apply their own threshold.
+    """
+
+    def classify(self, log_text: str) -> list[tuple[str, float]]:
+        """Return ranked (category, confidence) pairs for *log_text*.
+
+        Parameters
+        ----------
+        log_text:
+            Raw or partially normalised Airflow task-instance log text.
+
+        Returns
+        -------
+        list[tuple[str, float]]
+            Categories with non-zero confidence, sorted highest first.
+            Empty list when no rule fires.
+        """
+        scores: dict[str, float] = {}
+        for category, rules in _RULES.items():
+            total = sum(weight for pattern, weight in rules if pattern.search(log_text))
+            if total > 0:
+                scores[category] = min(total, 1.0)
+
+        return sorted(scores.items(), key=lambda item: item[1], reverse=True)

--- a/team_project/tests/test_classifier.py
+++ b/team_project/tests/test_classifier.py
@@ -1,0 +1,119 @@
+"""Tests for the heuristic failure classifier."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import pytest
+
+from dag_triage.classifier import FailureClassifier
+
+
+@pytest.fixture
+def clf() -> FailureClassifier:
+    return FailureClassifier()
+
+
+def top_category(results: list[tuple[str, float]]) -> str:
+    assert results, "Expected at least one category but got empty list"
+    return results[0][0]
+
+
+# ---------------------------------------------------------------------------
+# TRANSIENT
+# ---------------------------------------------------------------------------
+
+
+def test_transient_timeout(clf: FailureClassifier) -> None:
+    log = "Task failed after 30s: connection reset by peer, timeout exceeded"
+    assert top_category(clf.classify(log)) == "TRANSIENT"
+
+
+def test_transient_503_retry_exhausted(clf: FailureClassifier) -> None:
+    log = "Received HTTP 503 Service Unavailable. Retry exhausted after 5 attempts."
+    assert top_category(clf.classify(log)) == "TRANSIENT"
+
+
+# ---------------------------------------------------------------------------
+# DATA_QUALITY
+# ---------------------------------------------------------------------------
+
+
+def test_data_quality_null_value(clf: FailureClassifier) -> None:
+    log = "Insert failed: null value in column 'user_id' violates not-null constraint"
+    assert top_category(clf.classify(log)) == "DATA_QUALITY"
+
+
+def test_data_quality_schema_mismatch(clf: FailureClassifier) -> None:
+    log = "Schema mismatch detected: expected INT got STRING. Validation error on row 42."
+    assert top_category(clf.classify(log)) == "DATA_QUALITY"
+
+
+# ---------------------------------------------------------------------------
+# RESOURCE
+# ---------------------------------------------------------------------------
+
+
+def test_resource_oom(clf: FailureClassifier) -> None:
+    log = "java.lang.OutOfMemoryError: Java heap space"
+    assert top_category(clf.classify(log)) == "RESOURCE"
+
+
+def test_resource_oomkilled(clf: FailureClassifier) -> None:
+    log = "Container OOMKilled: memory limit of 512Mi exceeded"
+    assert top_category(clf.classify(log)) == "RESOURCE"
+
+
+# ---------------------------------------------------------------------------
+# CODE
+# ---------------------------------------------------------------------------
+
+
+def test_code_type_error(clf: FailureClassifier) -> None:
+    log = "TypeError: unsupported operand type(s) for +: 'int' and 'str'"
+    assert top_category(clf.classify(log)) == "CODE"
+
+
+def test_code_import_error(clf: FailureClassifier) -> None:
+    log = "ImportError: No module named 'pandas'. Check your dependencies."
+    assert top_category(clf.classify(log)) == "CODE"
+
+
+# ---------------------------------------------------------------------------
+# EXTERNAL_DEPENDENCY
+# ---------------------------------------------------------------------------
+
+
+def test_external_dependency_ssl(clf: FailureClassifier) -> None:
+    log = "SSL: CERTIFICATE_VERIFY_FAILED certificate verify failed (_ssl.c:1129)"
+    assert top_category(clf.classify(log)) == "EXTERNAL_DEPENDENCY"
+
+
+def test_external_dependency_dns(clf: FailureClassifier) -> None:
+    log = "DNS resolution failed: host unreachable for endpoint db.internal"
+    assert top_category(clf.classify(log)) == "EXTERNAL_DEPENDENCY"
+
+
+# ---------------------------------------------------------------------------
+# Unclassifiable — should return empty list
+# ---------------------------------------------------------------------------
+
+
+def test_unclassifiable_returns_empty(clf: FailureClassifier) -> None:
+    log = "Task started successfully. All checks passed."
+    assert clf.classify(log) == []
+
+
+# ---------------------------------------------------------------------------
+# General contract: result is sorted descending by confidence
+# ---------------------------------------------------------------------------
+
+
+def test_results_sorted_descending(clf: FailureClassifier) -> None:
+    log = "TypeError: bad type. Also got 503 timeout."
+    results = clf.classify(log)
+    confidences = [conf for _, conf in results]
+    assert confidences == sorted(confidences, reverse=True)


### PR DESCRIPTION
Adds a heuristic failure classifier under `team_project/src/dag_triage/`.

Files added (no existing code modified):

- `src/dag_triage/__init__.py` — package init with version and team docstring
- `src/dag_triage/classifier.py` — `FailureClassifier.classify(log_text)` returns ranked `(category, confidence)` tuples across five categories: `TRANSIENT`, `DATA_QUALITY`, `RESOURCE`, `CODE`, `EXTERNAL_DEPENDENCY`
- `tests/__init__.py` — empty test package marker
- `tests/test_classifier.py` — 12 pytest cases (2 per category + 1 unclassifiable + 1 sort-order contract), all passing

The classifier never asserts a single label; it returns all non-zero categories ranked by accumulated regex-match confidence so engineer judgment is preserved.
