### PR TITLE
feat(team_project): add Airflow log normalization layer

### DIFF
--- a/team_project/src/dag_triage/log_parser.py
+++ b/team_project/src/dag_triage/log_parser.py
@@ -1,0 +1,56 @@
+"""Airflow task-instance log normalization layer."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Matches: [YYYY-MM-DDTHH:MM:SS.fff+0000] {filename:line} LEVEL - message
+_HEADER = re.compile(
+    r"^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+[+-]\d{4})\]"
+    r"\s+\{([^}]+)\}"
+    r"\s+([A-Z]+)"
+    r"\s+-\s+(.*)"
+)
+
+
+@dataclass
+class LogRecord:
+    timestamp: str
+    level: str
+    source: str
+    message: str
+    traceback: str | None = None
+
+
+def parse_log(raw_log: str) -> list[LogRecord]:
+    """Parse an Airflow task-instance log string into a list of LogRecords.
+
+    Lines matching the standard Airflow header format become new records.
+    Non-header lines that immediately follow an ERROR record are collected
+    into that record's ``traceback`` field.  All other non-header lines
+    (malformed lines, or continuations after a non-ERROR record) are
+    silently skipped.
+    """
+    records: list[LogRecord] = []
+    tb_lines: list[str] = []
+
+    def _flush_traceback() -> None:
+        if tb_lines and records:
+            records[-1].traceback = "\n".join(tb_lines)
+        tb_lines.clear()
+
+    for line in raw_log.splitlines():
+        m = _HEADER.match(line)
+        if m:
+            _flush_traceback()
+            timestamp, source, level, message = m.groups()
+            records.append(
+                LogRecord(timestamp=timestamp, level=level, source=source, message=message)
+            )
+        elif records and records[-1].level == "ERROR":
+            tb_lines.append(line)
+        # else: malformed or non-traceback continuation — skip silently
+
+    _flush_traceback()
+    return records

--- a/team_project/tests/test_log_parser.py
+++ b/team_project/tests/test_log_parser.py
@@ -1,0 +1,95 @@
+"""Tests for the Airflow log normalization layer."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from dag_triage.log_parser import LogRecord, parse_log
+
+
+# ---------------------------------------------------------------------------
+# Case 1: single INFO line
+# ---------------------------------------------------------------------------
+
+
+def test_single_info_line() -> None:
+    raw = "[2024-01-15T10:30:45.123+0000] {dag.py:42} INFO - Starting task"
+    records = parse_log(raw)
+
+    assert len(records) == 1
+    r = records[0]
+    assert r.timestamp == "2024-01-15T10:30:45.123+0000"
+    assert r.level == "INFO"
+    assert r.source == "dag.py:42"
+    assert r.message == "Starting task"
+    assert r.traceback is None
+
+
+# ---------------------------------------------------------------------------
+# Case 2: multi-line Python traceback attached to the ERROR record
+# ---------------------------------------------------------------------------
+
+
+def test_error_with_multiline_traceback() -> None:
+    raw = (
+        "[2024-01-15T10:30:47.500+0000] {task_runner.py:88} ERROR - Task execution failed\n"
+        "Traceback (most recent call last):\n"
+        '  File "task_runner.py", line 88, in execute\n'
+        "    result = self.hook.run()\n"
+        "AttributeError: 'NoneType' object has no attribute 'run'"
+    )
+    records = parse_log(raw)
+
+    assert len(records) == 1
+    r = records[0]
+    assert r.level == "ERROR"
+    assert r.message == "Task execution failed"
+    assert r.traceback is not None
+    assert "Traceback (most recent call last):" in r.traceback
+    assert "AttributeError" in r.traceback
+
+
+# ---------------------------------------------------------------------------
+# Case 3: mixed log — INFO, WARNING, ERROR all parsed correctly
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_log_levels() -> None:
+    raw = (
+        "[2024-01-15T10:30:45.000+0000] {dag.py:1} INFO - Starting pipeline\n"
+        "[2024-01-15T10:30:45.800+0000] {dag.py:55} WARNING - Slow query detected\n"
+        "[2024-01-15T10:30:46.200+0000] {dag.py:99} ERROR - Connection refused"
+    )
+    records = parse_log(raw)
+
+    assert len(records) == 3
+    assert records[0].level == "INFO"
+    assert records[0].message == "Starting pipeline"
+    assert records[1].level == "WARNING"
+    assert records[1].message == "Slow query detected"
+    assert records[2].level == "ERROR"
+    assert records[2].message == "Connection refused"
+    assert records[0].traceback is None
+    assert records[1].traceback is None
+
+
+# ---------------------------------------------------------------------------
+# Case 4: malformed line between valid records is silently skipped
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_line_silently_skipped() -> None:
+    raw = (
+        "[2024-01-15T10:30:45.000+0000] {dag.py:1} INFO - First good line\n"
+        "!!! this line has no timestamp and is not after an ERROR !!!\n"
+        "[2024-01-15T10:30:46.000+0000] {dag.py:2} INFO - Second good line"
+    )
+    records = parse_log(raw)
+
+    assert len(records) == 2
+    assert records[0].message == "First good line"
+    assert records[1].message == "Second good line"
+    assert records[0].traceback is None


### PR DESCRIPTION
Adds a log normalization layer under `team_project/src/dag_triage/`.

Files added (no existing code modified):

- `src/dag_triage/log_parser.py` — `LogRecord` dataclass and `parse_log(raw_log)` function that parses the standard Airflow task-instance log format `[YYYY-MM-DDTHH:MM:SS.fff+0000] {file:line} LEVEL - message`. Multi-line tracebacks following ERROR records are attached to the preceding record's `traceback` field; malformed lines are silently skipped.
- `tests/test_log_parser.py` — 4 pytest cases: single INFO line, multi-line traceback on ERROR record, mixed INFO/WARNING/ERROR log, and malformed line silently skipped. All passing.
