### PR TITLE
chore: add GitHub issue template for sprint backlog items (closes #24)

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint_backlog_item.md
+++ b/.github/ISSUE_TEMPLATE/sprint_backlog_item.md
@@ -1,0 +1,28 @@
+---
+name: Sprint Backlog Item
+about: Template for new sprint backlog items following INVEST criteria
+title: "As a [role], I want [capability], so that [outcome]"
+labels: ''
+assignees: ''
+---
+
+## User Story
+As a [role],
+I want [capability],
+so that [outcome].
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## INVEST Check
+- **Independent:** yes/no - reason
+- **Negotiable:** yes/no - reason
+- **Valuable:** yes/no - reason
+- **Estimable:** S / M / L
+- **Small:** yes/no - fits within one sprint
+- **Testable:** yes/no - how it will be verified
+
+## Linked PR / Commit
+Link the PR or commit that satisfies this story once complete.


### PR DESCRIPTION
Closes #24

Adds reusable issue template under .github/ISSUE_TEMPLATE/ capturing
user story format, acceptance criteria, INVEST check, and linked PR
fields. Template matches the format used on issues #1, #47, #48, #49.