### PR TITLE
feat: add remediation checklist generator from failure category

### DIFF
--- a/team_project/src/dag_triage/checklist_generator.py
+++ b/team_project/src/dag_triage/checklist_generator.py
@@ -1,0 +1,44 @@
+"""checklist_generator.py
+Milestone Mavericks, CSS 566A, UW Bothell, Spring 2026.
+
+Generates a categorized remediation checklist from RemediationKB
+lookup results. Each checklist item is session-local with no
+persistence in v1.
+"""
+
+from dataclasses import dataclass, field
+from dag_triage.remediation_kb import RemediationKB, Remediation
+
+
+@dataclass
+class ChecklistItem:
+    step: str
+    tried: bool = False
+
+
+@dataclass
+class Checklist:
+    category: str
+    items: list[ChecklistItem] = field(default_factory=list)
+
+    def mark_tried(self, index: int) -> None:
+        if 0 <= index < len(self.items):
+            self.items[index].tried = True
+
+
+def generate_checklist(category: str, log_signature: str = "") -> Checklist:
+    """Return a Checklist for the given failure category.
+
+    Pulls remediation steps from RemediationKB and flattens
+    all steps into ChecklistItems. Session-local only; no
+    persistence in v1.
+    """
+    kb = RemediationKB()
+    remediations: list[Remediation] = kb.lookup(category, log_signature)
+
+    checklist = Checklist(category=category)
+    for remediation in remediations:
+        for step in remediation.steps:
+            checklist.items.append(ChecklistItem(step=step))
+
+    return checklist


### PR DESCRIPTION
Closes #34

Adds checklist_generator.py which pulls RemediationKB entries for a
given failure category and flattens all steps into ChecklistItems.
Each item carries a session-local tried flag (no persistence in v1).

Acceptance criteria status:
- Each failure category has 3+ checklist items: Done via remediation_kb.yaml
- Checklist rendered in Triage panel: Sprint 5 UI
- Operators can mark items as tried: session-local flag implemented here