### PR TITLE
chore: add sample failed DAG and end-to-end demo triage script

### DIFF
--- a/team_project/demo/demo_triage.py
+++ b/team_project/demo/demo_triage.py
@@ -1,0 +1,39 @@
+"""demo_triage.py
+Milestone Mavericks, CSS 566A, UW Bothell, Spring 2026.
+
+Runs the full triage pipeline on the sample failed DAG log output
+to demonstrate end-to-end classification and remediation lookup.
+"""
+
+from dag_triage.log_parser import parse_log
+from dag_triage.classifier import FailureClassifier
+from dag_triage.checklist_generator import generate_checklist
+
+SAMPLE_LOG = (
+    "[2026-06-01T10:00:00.000+0000] {sample_failed_dag.py:18} ERROR - "
+    "host unreachable: DNS resolution failed for external-db.example.com. "
+    "Connection 'external_db' is not configured in Airflow connections."
+)
+
+
+def run_demo():
+    records = parse_log(SAMPLE_LOG)
+    full_text = " ".join(
+        r.message + (r.traceback or "") for r in records
+    )
+
+    candidates = FailureClassifier().classify(full_text)
+    print("Classified failure candidates:")
+    for category, confidence in candidates:
+        print(f"  {category}: {confidence:.2f}")
+
+    if candidates:
+        top_category = candidates[0][0]
+        checklist = generate_checklist(top_category, full_text)
+        print(f"\nRemediation checklist for {top_category}:")
+        for i, item in enumerate(checklist.items, 1):
+            print(f"  {i}. {item.step}")
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/team_project/demo/sample_failed_dag.py
+++ b/team_project/demo/sample_failed_dag.py
@@ -1,0 +1,31 @@
+"""sample_failed_dag.py
+Milestone Mavericks, CSS 566A, UW Bothell, Spring 2026.
+
+Sample DAG that intentionally fails with a missing connection error
+to demonstrate the AI-assisted triage plugin end-to-end.
+"""
+
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+
+def fail_with_missing_connection():
+    raise Exception(
+        "host unreachable: DNS resolution failed for external-db.example.com. "
+        "Connection 'external_db' is not configured in Airflow connections."
+    )
+
+
+with DAG(
+    dag_id="sample_failed_dag",
+    start_date=datetime(2026, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["demo", "triage"],
+) as dag:
+
+    trigger_failure = PythonOperator(
+        task_id="trigger_failure",
+        python_callable=fail_with_missing_connection,
+    )


### PR DESCRIPTION
Closes #37

Adds team_project/demo/ with two files:
- sample_failed_dag.py: intentionally fails with a missing Airflow
  connection error to exercise the EXTERNAL_DEPENDENCY triage path
- demo_triage.py: runs the full pipeline (parse_log -> classify ->
  generate_checklist) on the sample log output and prints results

Recording of the demo walkthrough will be embedded in the final
paper submission.