### PR TITLE
#17 - Finalize problem framing doc and PRFAQ index

### DIFF
--- a/team_project/README.md
+++ b/team_project/README.md
@@ -26,6 +26,16 @@ layer, and surfaces ranked remediation candidates to the on-call engineer.
 A local-only execution mode ensures the plugin can run without sending log data
 to an external API, satisfying data-residency requirements.
 
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [`docs/prfaq/README.md`](docs/prfaq/README.md) | PRFAQ working folder — index of problem framing and related docs |
+| [`docs/PRODUCT_PROBLEM.md`](docs/PRODUCT_PROBLEM.md) | Canonical problem framing (issue #17) |
+| [`docs/PERSONAS.md`](docs/PERSONAS.md) | Target personas and upstream issue evidence |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Plugin architecture |
+| [`docs/PROJECT_PLAN.md`](docs/PROJECT_PLAN.md) | Sprint plan |
+
 ## Links
 
 | Resource | URL |

--- a/team_project/docs/PERSONAS.md
+++ b/team_project/docs/PERSONAS.md
@@ -16,8 +16,11 @@ data engineers to apply fixes.
 - Repeated transient failures are indistinguishable from real failures without
   log context
 
-**Upstream evidence:** apache/airflow issues referencing manual log triage
-overhead in production operator workflows.
+**Upstream evidence:**
+
+| Issue | Pain point | Summary |
+|-------|------------|---------|
+| [apache/airflow#28116](https://github.com/apache/airflow/issues/28116) | No built-in failure categorization; repeated transient failures indistinguishable from real failures without log context | Scheduler-detected failures (for example zombie jobs) are marked failed in the UI with no reason in the Task Instance Logs tab, so platform operators must hunt through scheduler logs to learn whether the root cause is infrastructure or task logic. |
 
 ---
 
@@ -38,8 +41,11 @@ own code failures.
 - No structured root-cause output means escalation to platform team is the
   default, adding latency
 
-**Upstream evidence:** apache/airflow community posts referencing confusion
-over failure attribution in multi-team DAG environments.
+**Upstream evidence:**
+
+| Issue | Pain point | Summary |
+|-------|------------|---------|
+| [apache/airflow#43171](https://github.com/apache/airflow/issues/43171) | Cannot tell data quality vs. resource constraint without deep log inspection; escalation to platform team is the default | The Airflow Debugging Survey 2024 found 41.7% of respondents do not consider native error messages actionable, leaving DAG consumers without Airflow expertise unable to attribute failures on their own. |
 
 ---
 
@@ -60,5 +66,8 @@ escalate, or fix.
 - Time-to-first-diagnosis extends beyond acceptable incident SLA without
   structured triage
 
-**Upstream evidence:** apache/airflow operator community discussions on
-improving Task Instance failure visibility for non-expert operators.
+**Upstream evidence:**
+
+| Issue | Pain point | Summary |
+|-------|------------|---------|
+| [apache/airflow#63736](https://github.com/apache/airflow/issues/63736) | Raw traceback text is not actionable; time-to-first-diagnosis extends beyond incident SLA | Exception stack traces stored in Elasticsearch were silently dropped from the Task Instance logs tab, leaving on-call engineers with only "Task failed with exception" and no traceback to act on. |

--- a/team_project/docs/PRODUCT_PROBLEM.md
+++ b/team_project/docs/PRODUCT_PROBLEM.md
@@ -1,19 +1,41 @@
-# Product Problem: AI-Assisted DAG Failure Triage
+# Problem Framing: AI-Assisted Dag Failure Triage
+
+Canonical product problem document for Milestone Mavericks. This framing is the
+prerequisite for the PRFAQ press release. Indexed from
+[`prfaq/README.md`](prfaq/README.md).
 
 ## Problem Statement
 
 Platform engineers running production Apache Airflow spend significant time
-manually parsing task logs to diagnose DAG failures. The native Task Instance
+manually parsing task logs to diagnose Dag failures. The native Task Instance
 view surfaces raw logs only, with no failure categorization, root-cause
 summary, or remediation guidance. This creates unnecessary latency in incident
 response and places a high cognitive burden on on-call engineers.
 
+Machine-learning engineers and operational data users hit the same wall: they
+open the Task Instance view under alert pressure, scroll unstructured logs, and
+cannot quickly tell whether to retry, escalate, or fix — especially when
+failures span upstream data boundaries or platform infrastructure.
+
 ## Outcome Metric
 
-Reduce median time-to-first-diagnosis on failed DAG tasks from unassisted
+Reduce median time-to-first-diagnosis on failed Dag tasks from unassisted
 manual log inspection to under two minutes, measured on a curated Airflow
-failure corpus from DAG run failed state to engineer-identified root-cause
+failure corpus from Dag run failed state to engineer-identified root-cause
 category.
+
+## Target Personas
+
+Three primary users share this problem with different emphasis:
+
+| Persona | Primary pain |
+|---------|--------------|
+| Platform Engineer | Manual log triage at scale; no built-in failure categorization |
+| ML Engineer | Cannot attribute failures (data vs. code vs. resources) without Airflow depth |
+| On-Call Data Engineer | Raw logs are not actionable; no guided triage under SLA pressure |
+
+Full persona definitions, daily workflows, pain points, and upstream Apache
+Airflow issue evidence are in [`PERSONAS.md`](PERSONAS.md).
 
 ## Solution Boundary
 
@@ -25,47 +47,26 @@ Extends the Task Instance view (read-only plugin surface) to display:
 - Remediation checklist of at least three suggested next steps with
   links to official Airflow documentation
 
+The classifier returns ranked candidates with confidence scores rather than a
+single forced label, so engineers retain judgment in ambiguous cases.
+
 The feature is opt-in via an Airflow configuration flag and disabled by
 default. No modifications to the Airflow core scheduler or executor are
-required.
+required. A local-only mode bypasses external LLM calls for data-residency
+constraints.
 
-## Architecture
+Technical architecture and layer boundaries are documented in
+[`ARCHITECTURE.md`](ARCHITECTURE.md). Sprint delivery plan is in
+[`PROJECT_PLAN.md`](PROJECT_PLAN.md).
 
-The plugin implements a four-layer pipeline:
+## Team Sign-Off
 
-  Raw Airflow logs
-        |
-        v
-  Log Normalization Layer   -> emits structured LogRecord dataclass
-        |
-        v
-  Heuristic Classifier      -> returns ranked (category, confidence) list
-        |
-        v
-  LLM Summarization Layer   -> optional; skipped when local_only=true
-        |
-        v
-  Remediation KB + UI       -> displays runbooks alongside ranked candidates
+| Reviewer | Role | Approval |
+|----------|------|----------|
+| Sharan Saravanan | Project scoping and engineering (author) | Pending |
+| Poorani T S | Engineering and coordination | Pending |
+| Sohail Anwar | Scrum Master | Pending |
 
-Ranked candidates are returned rather than a single label to preserve
-engineer judgment in ambiguous multi-signal failure cases.
-
-## Implementation Evidence
-
-| Layer | Module | Tests |
-|-------|--------|-------|
-| Log normalization | src/dag_triage/log_parser.py | 4 passing |
-| Heuristic classification | src/dag_triage/classifier.py | 12 passing |
-| Remediation lookup | src/dag_triage/remediation_kb.py | 10 passing |
-
-Total: 26 tests passing across three modules.
-
-## Acceptance Criteria Status
-
-| Criterion | Status |
-|-----------|--------|
-| Triage section visible on failed Task Instance | Sprint 5 - UI |
-| Failure category displayed | Done - classifier.py |
-| Root-cause summary from task logs | Done - log_parser.py |
-| Remediation checklist (3+ steps) | Done - remediation_kb.py |
-| Opt-in config flag, disabled by default | Sprint 5 - plugin registration |
+Formal sign-off is recorded by updating this table and via pull-request
+approval on the commit linked to issue #17. All three approvals are required
+before this document is considered finalized.

--- a/team_project/docs/prfaq/README.md
+++ b/team_project/docs/prfaq/README.md
@@ -1,0 +1,28 @@
+# PRFAQ Working Folder
+
+Working-backwards artifacts for Milestone Mavericks (CSS 566A, Spring 2026).
+The press release and FAQs live in the course submission; this folder indexes
+the repository copies that feed the PRFAQ narrative.
+
+## Canonical documents
+
+| Document | Purpose |
+|----------|---------|
+| [`../PRODUCT_PROBLEM.md`](../PRODUCT_PROBLEM.md) | **Problem framing** — problem statement, outcome metric, personas, solution boundary, team sign-off (issue #17) |
+| [`../PERSONAS.md`](../PERSONAS.md) | Target user personas with upstream Airflow issue evidence (issue #19) |
+| [`../ARCHITECTURE.md`](../ARCHITECTURE.md) | Four-layer plugin architecture and SOLID rationale |
+| [`../PROJECT_PLAN.md`](../PROJECT_PLAN.md) | Sprint timeline and deliverables |
+
+## Course submission
+
+The midterm PRFAQ-Plus press release, customer FAQs, stakeholder FAQs, and
+requirements traceability were submitted as a course document outside this
+fork. Repository docs above are the source of truth for problem framing and
+persona evidence referenced in that paper.
+
+## Related links
+
+| Resource | URL |
+|----------|-----|
+| Fork | https://github.com/break-through-19/airflow |
+| Kanban board | https://github.com/users/break-through-19/projects/9 |


### PR DESCRIPTION
Refocus PRODUCT_PROBLEM.md as the canonical problem framing document: add
target personas, link to PERSONAS.md and ARCHITECTURE.md, and add a team
sign-off table for issue #17. Add docs/prfaq/README.md as the PRFAQ working
folder index and link documentation from team_project/README.md.
