### PR TITLE
#35 - Add classifier unit tests with TDD coverage gate and CI

### DIFF
--- a/.github/workflows/team-project-ci.yml
+++ b/.github/workflows/team-project-ci.yml
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: Team Project CI
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    paths:
+      - team_project/**
+      - .github/workflows/team-project-ci.yml
+  push:
+    branches:
+      - main
+    paths:
+      - team_project/**
+      - .github/workflows/team-project-ci.yml
+
+permissions:
+  contents: read
+
+jobs:
+  classifier-tests:
+    name: Classifier unit tests (>=80% coverage)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af2be863a4cc32277884e9a13dedcab22f899  # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest pytest-cov
+
+      - name: Run classifier test suite with coverage gate
+        working-directory: team_project
+        run: >
+          pytest tests/test_classifier.py
+          --cov=dag_triage.classifier
+          --cov-report=term-missing
+          --cov-fail-under=80

--- a/team_project/.test-venv/bin/coverage
+++ b/team_project/.test-venv/bin/coverage
@@ -1,0 +1,10 @@
+#!/bin/sh
+'''exec' "/Users/sharan/Downloads/Airflow Temp/Ours/team_project/.test-venv/bin/python3" "$0" "$@"
+' '''
+# -*- coding: utf-8 -*-
+import re
+import sys
+from coverage.cmdline import main
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())

--- a/team_project/.test-venv/bin/coverage-3.9
+++ b/team_project/.test-venv/bin/coverage-3.9
@@ -1,0 +1,10 @@
+#!/bin/sh
+'''exec' "/Users/sharan/Downloads/Airflow Temp/Ours/team_project/.test-venv/bin/python3" "$0" "$@"
+' '''
+# -*- coding: utf-8 -*-
+import re
+import sys
+from coverage.cmdline import main
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())

--- a/team_project/.test-venv/bin/coverage3
+++ b/team_project/.test-venv/bin/coverage3
@@ -1,0 +1,10 @@
+#!/bin/sh
+'''exec' "/Users/sharan/Downloads/Airflow Temp/Ours/team_project/.test-venv/bin/python3" "$0" "$@"
+' '''
+# -*- coding: utf-8 -*-
+import re
+import sys
+from coverage.cmdline import main
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())

--- a/team_project/README.md
+++ b/team_project/README.md
@@ -26,6 +26,16 @@ layer, and surfaces ranked remediation candidates to the on-call engineer.
 A local-only execution mode ensures the plugin can run without sending log data
 to an external API, satisfying data-residency requirements.
 
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [`docs/prfaq/README.md`](docs/prfaq/README.md) | PRFAQ working folder — index of problem framing and related docs |
+| [`docs/PRODUCT_PROBLEM.md`](docs/PRODUCT_PROBLEM.md) | Canonical problem framing (issue #17) |
+| [`docs/PERSONAS.md`](docs/PERSONAS.md) | Target personas and upstream issue evidence |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Plugin architecture |
+| [`docs/PROJECT_PLAN.md`](docs/PROJECT_PLAN.md) | Sprint plan |
+
 ## Links
 
 | Resource | URL |

--- a/team_project/docs/PERSONAS.md
+++ b/team_project/docs/PERSONAS.md
@@ -16,8 +16,11 @@ data engineers to apply fixes.
 - Repeated transient failures are indistinguishable from real failures without
   log context
 
-**Upstream evidence:** apache/airflow issues referencing manual log triage
-overhead in production operator workflows.
+**Upstream evidence:**
+
+| Issue | Pain point | Summary |
+|-------|------------|---------|
+| [apache/airflow#28116](https://github.com/apache/airflow/issues/28116) | No built-in failure categorization; repeated transient failures indistinguishable from real failures without log context | Scheduler-detected failures (for example zombie jobs) are marked failed in the UI with no reason in the Task Instance Logs tab, so platform operators must hunt through scheduler logs to learn whether the root cause is infrastructure or task logic. |
 
 ---
 
@@ -38,8 +41,11 @@ own code failures.
 - No structured root-cause output means escalation to platform team is the
   default, adding latency
 
-**Upstream evidence:** apache/airflow community posts referencing confusion
-over failure attribution in multi-team DAG environments.
+**Upstream evidence:**
+
+| Issue | Pain point | Summary |
+|-------|------------|---------|
+| [apache/airflow#43171](https://github.com/apache/airflow/issues/43171) | Cannot tell data quality vs. resource constraint without deep log inspection; escalation to platform team is the default | The Airflow Debugging Survey 2024 found 41.7% of respondents do not consider native error messages actionable, leaving DAG consumers without Airflow expertise unable to attribute failures on their own. |
 
 ---
 
@@ -60,5 +66,8 @@ escalate, or fix.
 - Time-to-first-diagnosis extends beyond acceptable incident SLA without
   structured triage
 
-**Upstream evidence:** apache/airflow operator community discussions on
-improving Task Instance failure visibility for non-expert operators.
+**Upstream evidence:**
+
+| Issue | Pain point | Summary |
+|-------|------------|---------|
+| [apache/airflow#63736](https://github.com/apache/airflow/issues/63736) | Raw traceback text is not actionable; time-to-first-diagnosis extends beyond incident SLA | Exception stack traces stored in Elasticsearch were silently dropped from the Task Instance logs tab, leaving on-call engineers with only "Task failed with exception" and no traceback to act on. |

--- a/team_project/docs/PRODUCT_PROBLEM.md
+++ b/team_project/docs/PRODUCT_PROBLEM.md
@@ -1,19 +1,41 @@
-# Product Problem: AI-Assisted DAG Failure Triage
+# Problem Framing: AI-Assisted Dag Failure Triage
+
+Canonical product problem document for Milestone Mavericks. This framing is the
+prerequisite for the PRFAQ press release. Indexed from
+[`prfaq/README.md`](prfaq/README.md).
 
 ## Problem Statement
 
 Platform engineers running production Apache Airflow spend significant time
-manually parsing task logs to diagnose DAG failures. The native Task Instance
+manually parsing task logs to diagnose Dag failures. The native Task Instance
 view surfaces raw logs only, with no failure categorization, root-cause
 summary, or remediation guidance. This creates unnecessary latency in incident
 response and places a high cognitive burden on on-call engineers.
 
+Machine-learning engineers and operational data users hit the same wall: they
+open the Task Instance view under alert pressure, scroll unstructured logs, and
+cannot quickly tell whether to retry, escalate, or fix — especially when
+failures span upstream data boundaries or platform infrastructure.
+
 ## Outcome Metric
 
-Reduce median time-to-first-diagnosis on failed DAG tasks from unassisted
+Reduce median time-to-first-diagnosis on failed Dag tasks from unassisted
 manual log inspection to under two minutes, measured on a curated Airflow
-failure corpus from DAG run failed state to engineer-identified root-cause
+failure corpus from Dag run failed state to engineer-identified root-cause
 category.
+
+## Target Personas
+
+Three primary users share this problem with different emphasis:
+
+| Persona | Primary pain |
+|---------|--------------|
+| Platform Engineer | Manual log triage at scale; no built-in failure categorization |
+| ML Engineer | Cannot attribute failures (data vs. code vs. resources) without Airflow depth |
+| On-Call Data Engineer | Raw logs are not actionable; no guided triage under SLA pressure |
+
+Full persona definitions, daily workflows, pain points, and upstream Apache
+Airflow issue evidence are in [`PERSONAS.md`](PERSONAS.md).
 
 ## Solution Boundary
 
@@ -25,47 +47,26 @@ Extends the Task Instance view (read-only plugin surface) to display:
 - Remediation checklist of at least three suggested next steps with
   links to official Airflow documentation
 
+The classifier returns ranked candidates with confidence scores rather than a
+single forced label, so engineers retain judgment in ambiguous cases.
+
 The feature is opt-in via an Airflow configuration flag and disabled by
 default. No modifications to the Airflow core scheduler or executor are
-required.
+required. A local-only mode bypasses external LLM calls for data-residency
+constraints.
 
-## Architecture
+Technical architecture and layer boundaries are documented in
+[`ARCHITECTURE.md`](ARCHITECTURE.md). Sprint delivery plan is in
+[`PROJECT_PLAN.md`](PROJECT_PLAN.md).
 
-The plugin implements a four-layer pipeline:
+## Team Sign-Off
 
-  Raw Airflow logs
-        |
-        v
-  Log Normalization Layer   -> emits structured LogRecord dataclass
-        |
-        v
-  Heuristic Classifier      -> returns ranked (category, confidence) list
-        |
-        v
-  LLM Summarization Layer   -> optional; skipped when local_only=true
-        |
-        v
-  Remediation KB + UI       -> displays runbooks alongside ranked candidates
+| Reviewer | Role | Approval |
+|----------|------|----------|
+| Sharan Saravanan | Project scoping and engineering (author) | Pending |
+| Poorani T S | Engineering and coordination | Pending |
+| Sohail Anwar | Scrum Master | Pending |
 
-Ranked candidates are returned rather than a single label to preserve
-engineer judgment in ambiguous multi-signal failure cases.
-
-## Implementation Evidence
-
-| Layer | Module | Tests |
-|-------|--------|-------|
-| Log normalization | src/dag_triage/log_parser.py | 4 passing |
-| Heuristic classification | src/dag_triage/classifier.py | 12 passing |
-| Remediation lookup | src/dag_triage/remediation_kb.py | 10 passing |
-
-Total: 26 tests passing across three modules.
-
-## Acceptance Criteria Status
-
-| Criterion | Status |
-|-----------|--------|
-| Triage section visible on failed Task Instance | Sprint 5 - UI |
-| Failure category displayed | Done - classifier.py |
-| Root-cause summary from task logs | Done - log_parser.py |
-| Remediation checklist (3+ steps) | Done - remediation_kb.py |
-| Opt-in config flag, disabled by default | Sprint 5 - plugin registration |
+Formal sign-off is recorded by updating this table and via pull-request
+approval on the commit linked to issue #17. All three approvals are required
+before this document is considered finalized.

--- a/team_project/docs/prfaq/README.md
+++ b/team_project/docs/prfaq/README.md
@@ -1,0 +1,28 @@
+# PRFAQ Working Folder
+
+Working-backwards artifacts for Milestone Mavericks (CSS 566A, Spring 2026).
+The press release and FAQs live in the course submission; this folder indexes
+the repository copies that feed the PRFAQ narrative.
+
+## Canonical documents
+
+| Document | Purpose |
+|----------|---------|
+| [`../PRODUCT_PROBLEM.md`](../PRODUCT_PROBLEM.md) | **Problem framing** — problem statement, outcome metric, personas, solution boundary, team sign-off (issue #17) |
+| [`../PERSONAS.md`](../PERSONAS.md) | Target user personas with upstream Airflow issue evidence (issue #19) |
+| [`../ARCHITECTURE.md`](../ARCHITECTURE.md) | Four-layer plugin architecture and SOLID rationale |
+| [`../PROJECT_PLAN.md`](../PROJECT_PLAN.md) | Sprint timeline and deliverables |
+
+## Course submission
+
+The midterm PRFAQ-Plus press release, customer FAQs, stakeholder FAQs, and
+requirements traceability were submitted as a course document outside this
+fork. Repository docs above are the source of truth for problem framing and
+persona evidence referenced in that paper.
+
+## Related links
+
+| Resource | URL |
+|----------|-----|
+| Fork | https://github.com/break-through-19/airflow |
+| Kanban board | https://github.com/users/break-through-19/projects/9 |

--- a/team_project/pytest.ini
+++ b/team_project/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = src
+addopts = -ra

--- a/team_project/tests/test_classifier.py
+++ b/team_project/tests/test_classifier.py
@@ -1,4 +1,12 @@
-"""Tests for the heuristic failure classifier."""
+"""Tests for the heuristic failure classifier.
+
+Each regex rule in ``dag_triage.classifier._RULES`` has a dedicated parametrized
+case. When adding a new classification rule, follow red-green-refactor:
+
+1. Add a failing parametrized case here (red).
+2. Implement the pattern in ``FailureClassifier`` (green).
+3. Refactor shared weights or naming without changing behaviour (refactor).
+"""
 
 from __future__ import annotations
 
@@ -11,95 +19,136 @@ import pytest
 
 from dag_triage.classifier import FailureClassifier
 
+RULE_CASES = [
+    pytest.param("timeout", "TRANSIENT", "Request timeout after 30s", id="transient-timeout"),
+    pytest.param(
+        "connection_reset",
+        "TRANSIENT",
+        "Task failed: connection reset by peer",
+        id="transient-connection-reset",
+    ),
+    pytest.param("503", "TRANSIENT", "Received HTTP 503 Service Unavailable", id="transient-503"),
+    pytest.param("504", "TRANSIENT", "Upstream returned HTTP 504 Gateway Timeout", id="transient-504"),
+    pytest.param(
+        "retry_exhausted",
+        "TRANSIENT",
+        "Retry exhausted after 5 attempts",
+        id="transient-retry-exhausted",
+    ),
+    pytest.param(
+        "null_value",
+        "DATA_QUALITY",
+        "Insert failed: null value in column 'user_id'",
+        id="data-quality-null-value",
+    ),
+    pytest.param(
+        "schema_mismatch",
+        "DATA_QUALITY",
+        "Schema mismatch detected: expected INT got STRING",
+        id="data-quality-schema-mismatch",
+    ),
+    pytest.param(
+        "validation_error",
+        "DATA_QUALITY",
+        "Validation error on row 42",
+        id="data-quality-validation-error",
+    ),
+    pytest.param(
+        "type_mismatch",
+        "DATA_QUALITY",
+        "Type mismatch: expected int, got str",
+        id="data-quality-type-mismatch",
+    ),
+    pytest.param(
+        "out_of_memory",
+        "RESOURCE",
+        "java.lang.OutOfMemoryError: Java heap space",
+        id="resource-out-of-memory",
+    ),
+    pytest.param(
+        "oomkilled",
+        "RESOURCE",
+        "Container OOMKilled: memory limit of 512Mi exceeded",
+        id="resource-oomkilled",
+    ),
+    pytest.param("disk_full", "RESOURCE", "Cannot write: disk full on /data", id="resource-disk-full"),
+    pytest.param(
+        "memory_limit",
+        "RESOURCE",
+        "Pod exceeded memory limit of 1Gi",
+        id="resource-memory-limit",
+    ),
+    pytest.param(
+        "type_error",
+        "CODE",
+        "TypeError: unsupported operand type(s) for +: 'int' and 'str'",
+        id="code-type-error",
+    ),
+    pytest.param("key_error", "CODE", "KeyError: 'missing_key'", id="code-key-error"),
+    pytest.param(
+        "attribute_error",
+        "CODE",
+        "AttributeError: 'NoneType' object has no attribute 'value'",
+        id="code-attribute-error",
+    ),
+    pytest.param("name_error", "CODE", "NameError: name 'undefined_var' is not defined", id="code-name-error"),
+    pytest.param(
+        "import_error",
+        "CODE",
+        "ImportError: No module named 'pandas'",
+        id="code-import-error",
+    ),
+    pytest.param(
+        "dns",
+        "EXTERNAL_DEPENDENCY",
+        "DNS resolution failed for db.internal",
+        id="external-dns",
+    ),
+    pytest.param(
+        "host_unreachable",
+        "EXTERNAL_DEPENDENCY",
+        "Host unreachable for endpoint db.internal",
+        id="external-host-unreachable",
+    ),
+    pytest.param(
+        "certificate",
+        "EXTERNAL_DEPENDENCY",
+        "Certificate verify failed: invalid certificate chain",
+        id="external-certificate",
+    ),
+    pytest.param(
+        "ssl",
+        "EXTERNAL_DEPENDENCY",
+        "SSL: CERTIFICATE_VERIFY_FAILED certificate verify failed",
+        id="external-ssl",
+    ),
+    pytest.param(
+        "refused",
+        "EXTERNAL_DEPENDENCY",
+        "Connection refused on port 443",
+        id="external-refused",
+    ),
+]
+
 
 @pytest.fixture
 def clf() -> FailureClassifier:
     return FailureClassifier()
 
 
-def top_category(results: list[tuple[str, float]]) -> str:
-    assert results, "Expected at least one category but got empty list"
-    return results[0][0]
-
-
-# ---------------------------------------------------------------------------
-# TRANSIENT
-# ---------------------------------------------------------------------------
-
-
-def test_transient_timeout(clf: FailureClassifier) -> None:
-    log = "Task failed after 30s: connection reset by peer, timeout exceeded"
-    assert top_category(clf.classify(log)) == "TRANSIENT"
-
-
-def test_transient_503_retry_exhausted(clf: FailureClassifier) -> None:
-    log = "Received HTTP 503 Service Unavailable. Retry exhausted after 5 attempts."
-    assert top_category(clf.classify(log)) == "TRANSIENT"
-
-
-# ---------------------------------------------------------------------------
-# DATA_QUALITY
-# ---------------------------------------------------------------------------
-
-
-def test_data_quality_null_value(clf: FailureClassifier) -> None:
-    log = "Insert failed: null value in column 'user_id' violates not-null constraint"
-    assert top_category(clf.classify(log)) == "DATA_QUALITY"
-
-
-def test_data_quality_schema_mismatch(clf: FailureClassifier) -> None:
-    log = "Schema mismatch detected: expected INT got STRING. Validation error on row 42."
-    assert top_category(clf.classify(log)) == "DATA_QUALITY"
-
-
-# ---------------------------------------------------------------------------
-# RESOURCE
-# ---------------------------------------------------------------------------
-
-
-def test_resource_oom(clf: FailureClassifier) -> None:
-    log = "java.lang.OutOfMemoryError: Java heap space"
-    assert top_category(clf.classify(log)) == "RESOURCE"
-
-
-def test_resource_oomkilled(clf: FailureClassifier) -> None:
-    log = "Container OOMKilled: memory limit of 512Mi exceeded"
-    assert top_category(clf.classify(log)) == "RESOURCE"
-
-
-# ---------------------------------------------------------------------------
-# CODE
-# ---------------------------------------------------------------------------
-
-
-def test_code_type_error(clf: FailureClassifier) -> None:
-    log = "TypeError: unsupported operand type(s) for +: 'int' and 'str'"
-    assert top_category(clf.classify(log)) == "CODE"
-
-
-def test_code_import_error(clf: FailureClassifier) -> None:
-    log = "ImportError: No module named 'pandas'. Check your dependencies."
-    assert top_category(clf.classify(log)) == "CODE"
-
-
-# ---------------------------------------------------------------------------
-# EXTERNAL_DEPENDENCY
-# ---------------------------------------------------------------------------
-
-
-def test_external_dependency_ssl(clf: FailureClassifier) -> None:
-    log = "SSL: CERTIFICATE_VERIFY_FAILED certificate verify failed (_ssl.c:1129)"
-    assert top_category(clf.classify(log)) == "EXTERNAL_DEPENDENCY"
-
-
-def test_external_dependency_dns(clf: FailureClassifier) -> None:
-    log = "DNS resolution failed: host unreachable for endpoint db.internal"
-    assert top_category(clf.classify(log)) == "EXTERNAL_DEPENDENCY"
-
-
-# ---------------------------------------------------------------------------
-# Unclassifiable — should return empty list
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(("rule_id", "expected_category", "log"), RULE_CASES)
+def test_classification_rule(
+    clf: FailureClassifier,
+    rule_id: str,
+    expected_category: str,
+    log: str,
+) -> None:
+    """Each rule fires independently and ranks its category first."""
+    results = clf.classify(log)
+    assert results, f"Rule {rule_id!r} should produce at least one category"
+    top_category, confidence = results[0]
+    assert top_category == expected_category
+    assert confidence > 0
 
 
 def test_unclassifiable_returns_empty(clf: FailureClassifier) -> None:
@@ -107,9 +156,8 @@ def test_unclassifiable_returns_empty(clf: FailureClassifier) -> None:
     assert clf.classify(log) == []
 
 
-# ---------------------------------------------------------------------------
-# General contract: result is sorted descending by confidence
-# ---------------------------------------------------------------------------
+def test_empty_log_returns_empty(clf: FailureClassifier) -> None:
+    assert clf.classify("") == []
 
 
 def test_results_sorted_descending(clf: FailureClassifier) -> None:
@@ -117,3 +165,17 @@ def test_results_sorted_descending(clf: FailureClassifier) -> None:
     results = clf.classify(log)
     confidences = [conf for _, conf in results]
     assert confidences == sorted(confidences, reverse=True)
+
+
+def test_multiple_categories_when_signals_overlap(clf: FailureClassifier) -> None:
+    log = "TypeError in worker. HTTP 503 timeout from upstream."
+    results = clf.classify(log)
+    categories = {category for category, _ in results}
+    assert "CODE" in categories
+    assert "TRANSIENT" in categories
+
+
+def test_confidence_capped_at_one(clf: FailureClassifier) -> None:
+    log = "timeout connection reset 503 504 retry exhausted"
+    scores = dict(clf.classify(log))
+    assert scores["TRANSIENT"] == 1.0


### PR DESCRIPTION
Expand test_classifier.py with one parametrized case per classification rule,
document red-green-refactor workflow, and add contract tests for confidence
capping and multi-category results. Add team_project/pytest.ini and
team-project-ci.yml to run the classifier suite with >=80% coverage on every PR.