### PR TITLE
[Ticket 28] Standardize Docker Compose development environment

### DIFF
--- a/team_project/.dockerignore
+++ b/team_project/.dockerignore
@@ -1,0 +1,12 @@
+.git
+__pycache__
+*.pyc
+.pytest_cache
+.ruff_cache
+*.egg-info
+demo/
+demo.py
+docs/
+tests/
+plugin/
+.venv

--- a/team_project/Dockerfile
+++ b/team_project/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile for DAG Triage Assistant development environment.
+# Extends the official Airflow image with the triage plugin pre-installed.
+FROM apache/airflow:3.0.1-python3.10
+
+USER airflow
+
+# Install the dag-triage plugin package (editable for live code changes).
+COPY --chown=airflow:root src/ /opt/airflow/dag-triage-src/src/
+COPY --chown=airflow:root pyproject.toml README.md /opt/airflow/dag-triage-src/
+COPY --chown=airflow:root data/ /opt/airflow/dag-triage-src/data/
+RUN pip install --no-cache-dir -e /opt/airflow/dag-triage-src/
+
+# Copy the plugin entry point so Airflow discovers it automatically.
+COPY --chown=airflow:root plugins/dag_triage_plugin.py /home/airflow/.local/lib/python3.10/site-packages/dag_triage_plugin.py
+
+# Copy sample DAGs for manual triage testing.
+COPY --chown=airflow:root dags/ /opt/airflow/dags/

--- a/team_project/README.md
+++ b/team_project/README.md
@@ -26,6 +26,45 @@ layer, and surfaces ranked remediation candidates to the on-call engineer.
 A local-only execution mode ensures the plugin can run without sending log data
 to an external API, satisfying data-residency requirements.
 
+## Quick Start (Docker Compose)
+
+Bring up a full Airflow environment with the triage plugin pre-installed — identical on macOS and Linux.
+
+```bash
+cd team_project
+docker compose up
+```
+
+| What | URL |
+|------|-----|
+| Airflow UI | http://localhost:8080 (admin / admin) |
+| Triage Panel | http://localhost:8080/triage-panel/ |
+
+A **sample failing DAG** (`sample_failing_dag`) is included — trigger it manually from the UI, then open the Triage Panel to see how the plugin classifies each failure type.
+
+### Teardown
+
+```bash
+docker compose down          # stop services, keep data
+```
+
+### Full Reset (wipe database and volumes)
+
+```bash
+docker compose down -v       # stop and remove all volumes
+docker compose up --build    # rebuild from scratch
+```
+
+### Without Docker
+
+Run the standalone demo (no Airflow or Docker required):
+
+```bash
+python team_project/demo.py
+```
+
+See [`plugin/README.md`](plugin/README.md) for the REST API reference.
+
 ## Documentation
 
 | Document | Description |

--- a/team_project/dags/sample_failing_dag.py
+++ b/team_project/dags/sample_failing_dag.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Sample DAG that intentionally fails for triage testing.
+
+Trigger manually from the Airflow UI, then open the Triage Panel at
+``/triage-panel/`` to see how the plugin classifies each failure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.sdk import DAG, task
+
+
+@task
+def succeed():
+    """Run a healthy task without error."""
+    print("All systems go.")
+
+
+@task
+def fail_import_error():
+    """Simulate a missing-dependency failure (CODE category)."""
+    raise ImportError("No module named 'nonexistent_lib'")
+
+
+@task
+def fail_timeout():
+    """Simulate a transient network timeout (TRANSIENT category)."""
+    raise TimeoutError("Task failed after 30s: connection reset by peer, timeout exceeded")
+
+
+@task
+def fail_oom():
+    """Simulate an out-of-memory failure (RESOURCE category)."""
+    raise MemoryError("Container OOMKilled: memory limit of 512Mi exceeded")
+
+
+@task
+def fail_key_error():
+    """Simulate a code bug (CODE category)."""
+    data: dict = {}
+    _ = data["missing_key"]
+
+
+with DAG(
+    dag_id="sample_failing_dag",
+    description="Intentionally failing DAG for triage plugin testing",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["triage-test", "sample"],
+) as dag:
+    succeed() >> [fail_import_error(), fail_timeout(), fail_oom(), fail_key_error()]

--- a/team_project/docker-compose.yml
+++ b/team_project/docker-compose.yml
@@ -1,0 +1,85 @@
+# Docker Compose development environment for the DAG Triage Assistant plugin.
+#
+#   docker compose up              — start Airflow with the plugin pre-installed
+#   docker compose down            — stop all services
+#   docker compose down -v         — stop and remove volumes (full reset)
+#
+# Airflow UI: http://localhost:8080  (admin / admin)
+# Triage panel: http://localhost:8080/triage-panel/
+
+x-airflow-common: &airflow-common
+  build:
+    context: .
+    dockerfile: Dockerfile
+  environment: &airflow-env
+    AIRFLOW__CORE__EXECUTOR: LocalExecutor
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
+    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+    AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "true"
+    PYTHONPATH: /opt/airflow/dag-triage-src/src
+  volumes:
+    - ./dags:/opt/airflow/dags
+    - ./src:/opt/airflow/dag-triage-src/src
+    - ./data:/opt/airflow/dag-triage-src/data
+  depends_on:
+    postgres:
+      condition: service_healthy
+
+services:
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U airflow"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  airflow-init:
+    <<: *airflow-common
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - |
+        airflow db migrate &&
+        airflow users create \
+          --username admin \
+          --password admin \
+          --firstname Admin \
+          --lastname User \
+          --role Admin \
+          --email admin@example.com || true
+    restart: "no"
+
+  airflow-webserver:
+    <<: *airflow-common
+    command: airflow webserver --port 8080
+    ports:
+      - "8080:8080"
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  airflow-scheduler:
+    <<: *airflow-common
+    command: airflow scheduler
+    depends_on:
+      airflow-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary

- Add `Dockerfile` and `docker-compose.yml` so any team member can spin up a full
  Airflow environment with the DAG triage plugin pre-installed via a single
  `docker compose up` command.
- Include a sample failing DAG (`sample_failing_dag`) with four intentional failure
  types (ImportError, Timeout, OOM, KeyError) for manual triage testing against
  the plugin panel.
- Document setup, teardown, and full reset commands in the project README.

closes: #28

## What's included

| File | Purpose |
|---|---|
| `team_project/Dockerfile` | Extends `apache/airflow:3.0.1-python3.10`, installs `dag-triage` editable, copies plugin entry point and sample DAGs |
| `team_project/docker-compose.yml` | LocalExecutor stack: Postgres 14, db-init, webserver, scheduler — source-mounted for live reloading |
| `team_project/dags/sample_failing_dag.py` | 5-task DAG: one healthy task fans out to four failure modes covering each classifier category |
| `team_project/.dockerignore` | Excludes tests, docs, demo, .git from the build context |
| `team_project/README.md` | Quick Start, Teardown, and Full Reset sections added |

