### PR TITLE
Poorani ts/ticket 32 llm abstraction

### DIFF
--- a/team_project/src/dag_triage/llm_provider.py
+++ b/team_project/src/dag_triage/llm_provider.py
@@ -1,0 +1,258 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+LLM provider abstraction layer.
+
+Defines a provider interface (``LLMProvider``) and two implementations:
+
+* ``OpenAIProvider`` — calls the OpenAI chat completions API.
+* ``LocalRuleProvider`` — generates summaries from heuristic rules with
+  no external calls (zero-cost, zero-latency, zero-data-leakage fallback).
+
+Provider selection is driven by Airflow config (``[triage] llm_provider``)
+and resolved at runtime via ``get_llm_provider()``.  Callers (triage service,
+summarizer) depend only on the ``LLMProvider`` protocol — no provider-specific
+code leaks into those modules.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Response value object
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """Immutable result returned by every provider."""
+
+    text: str
+    provider_name: str
+    is_fallback: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Abstract provider
+# ---------------------------------------------------------------------------
+
+
+class LLMProvider(abc.ABC):
+    """
+    Contract that every LLM provider must satisfy.
+
+    Implementations must be stateless (safe to share across threads) and
+    must never raise on transient failures — return a best-effort
+    ``LLMResponse`` instead so the caller can still present *something*.
+    """
+
+    @abc.abstractmethod
+    def summarize(self, log_text: str, category: str, error_line: str | None = None) -> LLMResponse:
+        """
+        Produce a human-readable root-cause summary.
+
+        Parameters
+        ----------
+        log_text:
+            Raw or trimmed task-instance log.
+        category:
+            Top-ranked failure category from the classifier
+            (e.g. ``"TRANSIENT"``, ``"CODE"``).
+        error_line:
+            Optional extracted last error line for extra context.
+        """
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Short identifier for logging / response metadata."""
+
+
+# ---------------------------------------------------------------------------
+# Local rule-based provider (always available, no external calls)
+# ---------------------------------------------------------------------------
+
+_CATEGORY_HINTS: dict[str, str] = {
+    "TRANSIENT": (
+        "This looks like a transient infrastructure issue — the task hit a "
+        "timeout or received a retryable HTTP error. Retrying with back-off "
+        "is the safest first step."
+    ),
+    "DATA_QUALITY": (
+        "The failure is data-related — a schema mismatch, null-constraint "
+        "violation, or validation error. Inspect the source data and the "
+        "expected schema before re-running."
+    ),
+    "RESOURCE": (
+        "The task ran out of resources (memory or disk). Scale up the "
+        "worker, reduce batch size, or switch to chunked/streaming "
+        "processing."
+    ),
+    "CODE": (
+        "A Python exception indicates a bug in the task code — an import "
+        "error, type error, or missing key. Fix the code and redeploy."
+    ),
+    "EXTERNAL_DEPENDENCY": (
+        "An external service is unreachable — DNS failure, TLS certificate "
+        "issue, or connection refused. Check network connectivity and "
+        "service health."
+    ),
+}
+
+
+class LocalRuleProvider(LLMProvider):
+    """Generate summaries using deterministic rules — no external calls."""
+
+    @property
+    def name(self) -> str:
+        return "local-rule"
+
+    def summarize(self, log_text: str, category: str, error_line: str | None = None) -> LLMResponse:
+        """Build a summary from category hints and the last error line."""
+        hint = _CATEGORY_HINTS.get(category, "Review the task log for details.")
+        parts = [hint]
+        if error_line:
+            parts.append(f"Last error: {error_line}")
+        return LLMResponse(
+            text=" ".join(parts),
+            provider_name=self.name,
+            is_fallback=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI provider
+# ---------------------------------------------------------------------------
+
+
+class OpenAIProvider(LLMProvider):
+    """Call the OpenAI chat completions API for richer summaries."""
+
+    def __init__(self, *, api_key: str | None = None, model: str = "gpt-4o-mini") -> None:
+        self._api_key = api_key
+        self._model = model
+
+    @property
+    def name(self) -> str:
+        return "openai"
+
+    def summarize(self, log_text: str, category: str, error_line: str | None = None) -> LLMResponse:
+        """Call OpenAI and fall back to local rules on any failure."""
+        try:
+            return self._call_openai(log_text, category, error_line)
+        except Exception:
+            log.warning("OpenAI provider failed — falling back to local rules", exc_info=True)
+            fallback = LocalRuleProvider().summarize(log_text, category, error_line)
+            return LLMResponse(
+                text=fallback.text,
+                provider_name=self.name,
+                is_fallback=True,
+            )
+
+    def _call_openai(self, log_text: str, category: str, error_line: str | None) -> LLMResponse:
+        """Perform the actual API call."""
+        try:
+            import openai
+        except ImportError as exc:
+            raise RuntimeError(
+                "The 'openai' package is required for the OpenAI provider. "
+                "Install it with: pip install openai"
+            ) from exc
+
+        api_key = self._api_key or _read_api_key_from_config()
+        client = openai.OpenAI(api_key=api_key)
+
+        system_msg = (
+            "You are an Airflow operations assistant. Given a task failure log, "
+            "produce a concise (2-3 sentence) root-cause summary and one actionable "
+            "next step. Do not repeat the raw log."
+        )
+        user_msg = f"Category: {category}\n"
+        if error_line:
+            user_msg += f"Last error: {error_line}\n"
+        user_msg += f"\nLog excerpt (last 2000 chars):\n{log_text[-2000:]}"
+
+        response = client.chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "user", "content": user_msg},
+            ],
+            max_tokens=256,
+            temperature=0.3,
+        )
+        text = response.choices[0].message.content or ""
+        return LLMResponse(text=text.strip(), provider_name=self.name)
+
+
+# ---------------------------------------------------------------------------
+# Config-driven factory
+# ---------------------------------------------------------------------------
+
+_PROVIDERS: dict[str, type[LLMProvider]] = {
+    "local": LocalRuleProvider,
+    "openai": OpenAIProvider,
+}
+
+
+def _read_api_key_from_config() -> str:
+    """Read ``[triage] openai_api_key`` from Airflow config."""
+    from airflow.configuration import conf
+
+    key = conf.get("triage", "openai_api_key", fallback="")
+    if not key:
+        raise ValueError(
+            "OpenAI API key not configured. Set [triage] openai_api_key in airflow.cfg "
+            "or pass it via the AIRFLOW__TRIAGE__OPENAI_API_KEY environment variable."
+        )
+    return key
+
+
+def get_llm_provider() -> LLMProvider:
+    """
+    Return the configured LLM provider instance.
+
+    Reads ``[triage] llm_provider`` from ``airflow.cfg`` (default: ``local``).
+    Falls back to ``LocalRuleProvider`` if the requested provider cannot be
+    instantiated.
+    """
+    try:
+        from airflow.configuration import conf
+
+        provider_name = conf.get("triage", "llm_provider", fallback="local")
+    except ImportError:
+        # Outside Airflow (tests, demo) — default to local.
+        provider_name = "local"
+
+    provider_cls = _PROVIDERS.get(provider_name)
+    if provider_cls is None:
+        log.warning("Unknown LLM provider '%s' — falling back to 'local'", provider_name)
+        provider_cls = LocalRuleProvider
+
+    try:
+        return provider_cls()
+    except Exception:
+        log.warning(
+            "Failed to instantiate '%s' provider — falling back to 'local'", provider_name, exc_info=True
+        )
+        return LocalRuleProvider()

--- a/team_project/src/dag_triage/triage_service.py
+++ b/team_project/src/dag_triage/triage_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from dag_triage.classifier import FailureClassifier
+from dag_triage.llm_provider import LLMProvider, get_llm_provider
 from dag_triage.log_tail_store import get_task_log_tail
 from dag_triage.remediation_kb import Remediation, RemediationKB
 
@@ -88,10 +89,19 @@ def build_triage_summary(
     *,
     classifier: FailureClassifier | None = None,
     kb: RemediationKB | None = None,
+    llm_provider: LLMProvider | None = None,
 ) -> TriageSummary:
-    """Build a triage summary for a task instance from cached or fresh log tail."""
+    """
+    Build a triage summary for a task instance from cached or fresh log tail.
+
+    The ``llm_provider`` parameter accepts any ``LLMProvider`` implementation.
+    When omitted, the provider configured in ``[triage] llm_provider`` is used
+    (default: ``local``).  No provider-specific code exists in this module —
+    the abstraction is resolved externally.
+    """
     classifier = classifier or FailureClassifier()
     kb = kb or RemediationKB()
+    provider = llm_provider or get_llm_provider()
 
     log_result = get_task_log_tail(task_instance)
     log_text = log_result.text
@@ -106,13 +116,24 @@ def build_triage_summary(
         signature = log_text[:2000] if log_text else ""
         remediations = _to_remediation_items(kb.lookup(top_category, signature))
 
+    # Generate root-cause summary via the configured LLM provider.
+    # Falls back to the rule-based summary if the provider is unavailable
+    # or if no category was matched.
+    if categories:
+        top = categories[0]
+        last_error = _extract_last_error_line(log_text)
+        llm_response = provider.summarize(log_text, top.name, last_error)
+        root_cause_summary = llm_response.text
+    else:
+        root_cause_summary = _build_root_cause_summary(categories, log_text)
+
     summary_error = log_result.error
     if not log_available and summary_error is None:
         summary_error = "No log content available for this task instance."
 
     return TriageSummary(
         categories=categories,
-        root_cause_summary=_build_root_cause_summary(categories, log_text),
+        root_cause_summary=root_cause_summary,
         remediations=remediations,
         log_available=log_available,
         error=summary_error,

--- a/team_project/tests/test_llm_provider.py
+++ b/team_project/tests/test_llm_provider.py
@@ -1,0 +1,173 @@
+"""Tests for the LLM provider abstraction layer."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import pytest
+from dag_triage.llm_provider import (
+    LLMProvider,
+    LLMResponse,
+    LocalRuleProvider,
+    OpenAIProvider,
+    get_llm_provider,
+)
+
+# ---------------------------------------------------------------------------
+# LocalRuleProvider
+# ---------------------------------------------------------------------------
+
+
+class TestLocalRuleProvider:
+    """Verify the zero-dependency local fallback provider."""
+
+    @pytest.fixture
+    def provider(self) -> LocalRuleProvider:
+        return LocalRuleProvider()
+
+    def test_name(self, provider: LocalRuleProvider) -> None:
+        assert provider.name == "local-rule"
+
+    @pytest.mark.parametrize(
+        "category",
+        ["TRANSIENT", "DATA_QUALITY", "RESOURCE", "CODE", "EXTERNAL_DEPENDENCY"],
+    )
+    def test_summarize_returns_response_for_each_category(
+        self, provider: LocalRuleProvider, category: str
+    ) -> None:
+        resp = provider.summarize("some log", category)
+        assert isinstance(resp, LLMResponse)
+        assert resp.provider_name == "local-rule"
+        assert not resp.is_fallback
+        assert len(resp.text) > 0
+
+    def test_summarize_includes_error_line_when_provided(self, provider: LocalRuleProvider) -> None:
+        resp = provider.summarize("log", "CODE", error_line="KeyError: 'x'")
+        assert "KeyError: 'x'" in resp.text
+
+    def test_summarize_unknown_category_returns_generic(self, provider: LocalRuleProvider) -> None:
+        resp = provider.summarize("log", "UNKNOWN_CAT")
+        assert "Review the task log" in resp.text
+
+    def test_satisfies_abstract_interface(self, provider: LocalRuleProvider) -> None:
+        assert isinstance(provider, LLMProvider)
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider — fallback behaviour (no real API calls)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProviderFallback:
+    """Verify that OpenAI provider falls back to local rules on failure."""
+
+    def test_falls_back_when_openai_not_installed(self) -> None:
+        provider = OpenAIProvider(api_key="test-key")
+        with mock.patch.dict(sys.modules, {"openai": None}):
+            resp = provider.summarize("log text", "CODE", error_line="ImportError")
+        assert resp.is_fallback
+        assert resp.provider_name == "openai"
+        assert len(resp.text) > 0
+
+    def test_falls_back_on_api_error(self) -> None:
+        provider = OpenAIProvider(api_key="test-key")
+        fake_openai = mock.MagicMock()
+        fake_openai.OpenAI.return_value.chat.completions.create.side_effect = RuntimeError(
+            "connection refused"
+        )
+        with mock.patch.dict(sys.modules, {"openai": fake_openai}):
+            resp = provider.summarize("log", "TRANSIENT")
+        assert resp.is_fallback
+
+    def test_name(self) -> None:
+        assert OpenAIProvider(api_key="k").name == "openai"
+
+    def test_satisfies_abstract_interface(self) -> None:
+        assert isinstance(OpenAIProvider(api_key="k"), LLMProvider)
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider — successful API call (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProviderSuccess:
+    """Verify the happy path with a mocked OpenAI client."""
+
+    def test_returns_llm_text_on_success(self) -> None:
+        provider = OpenAIProvider(api_key="test-key", model="gpt-4o-mini")
+
+        fake_choice = mock.MagicMock()
+        fake_choice.message.content = "The task OOM-killed due to large payload."
+        fake_response = mock.MagicMock()
+        fake_response.choices = [fake_choice]
+
+        fake_openai = mock.MagicMock()
+        fake_openai.OpenAI.return_value.chat.completions.create.return_value = fake_response
+
+        with mock.patch.dict(sys.modules, {"openai": fake_openai}):
+            resp = provider.summarize("OOMKilled log", "RESOURCE")
+
+        assert not resp.is_fallback
+        assert resp.provider_name == "openai"
+        assert resp.text == "The task OOM-killed due to large payload."
+
+
+# ---------------------------------------------------------------------------
+# get_llm_provider() factory
+# ---------------------------------------------------------------------------
+
+
+class TestGetLlmProvider:
+    """Verify config-driven provider selection."""
+
+    def test_defaults_to_local_when_airflow_not_available(self) -> None:
+        with mock.patch.dict(sys.modules, {"airflow": None, "airflow.configuration": None}):
+            provider = get_llm_provider()
+        assert isinstance(provider, LocalRuleProvider)
+
+    def test_returns_local_for_explicit_config(self) -> None:
+        fake_conf = mock.MagicMock()
+        fake_conf.get.return_value = "local"
+        with mock.patch("dag_triage.llm_provider.conf", fake_conf, create=True):
+            with mock.patch(
+                "dag_triage.llm_provider.get_llm_provider.__module__",
+                create=True,
+            ):
+                # Simulate Airflow config returning "local"
+                provider = get_llm_provider()
+        assert isinstance(provider, (LocalRuleProvider, LLMProvider))
+
+    def test_unknown_provider_falls_back_to_local(self) -> None:
+        fake_conf = mock.MagicMock()
+        fake_conf.get.return_value = "nonexistent-provider"
+        fake_module = mock.MagicMock()
+        fake_module.conf = fake_conf
+        with mock.patch.dict(sys.modules, {"airflow.configuration": fake_module}):
+            provider = get_llm_provider()
+        assert isinstance(provider, LocalRuleProvider)
+
+
+# ---------------------------------------------------------------------------
+# No provider-specific code leaks — structural check
+# ---------------------------------------------------------------------------
+
+
+class TestNoProviderLeaks:
+    """Verify classifier and remediation_kb have no LLM/OpenAI imports."""
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            Path(__file__).parent.parent / "src" / "dag_triage" / "classifier.py",
+            Path(__file__).parent.parent / "src" / "dag_triage" / "remediation_kb.py",
+        ],
+    )
+    def test_no_openai_or_llm_import(self, module_path: Path) -> None:
+        source = module_path.read_text()
+        assert "openai" not in source.lower(), f"{module_path.name} must not reference openai"
+        assert "LLMProvider" not in source, f"{module_path.name} must not reference LLMProvider"


### PR DESCRIPTION
## Summary

- Add an `LLMProvider` abstract interface with two implementations: `OpenAIProvider`
  (hosted LLM) and `LocalRuleProvider` (deterministic rules, zero external calls).
- Provider selection is driven by `[triage] llm_provider` in `airflow.cfg` — defaults
  to `local` so the plugin works out of the box with no API keys or data leaving
  the cluster.
- Wire the provider into `build_triage_summary()` for root-cause summary generation;
  the triage service only references the abstract `LLMProvider` — no provider-specific
  code leaks into classifier, summarizer, or remediation modules.
- `OpenAIProvider` catches all failures and automatically falls back to local rules,
  ensuring the triage panel always returns a result.

closes: #32

## What's included

| File | Change |
|---|---|
| `src/dag_triage/llm_provider.py` | New — `LLMProvider` ABC, `LocalRuleProvider`, `OpenAIProvider`, config factory |
| `src/dag_triage/triage_service.py` | Modified — accepts optional `llm_provider` param, delegates summary to provider |
| `tests/test_llm_provider.py` | New — 19 tests covering interface, both providers, fallback, factory, and leak checks |

## Configuration

```ini
[triage]
llm_provider = local              # default — no external calls, no API key needed
# llm_provider = openai           # requires: pip install openai
# openai_api_key = sk-...         # or AIRFLOW__TRIAGE__OPENAI_API_KEY env var