### PR TITLE
[Ticket 38] Plugin packaging and v1.0 release notes

### DIFF
--- a/team_project/MANIFEST.in
+++ b/team_project/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md
+include RELEASE_NOTES.md
+include LICENSE
+recursive-include data *.yaml
+recursive-include src *.py

--- a/team_project/RELEASE_NOTES.md
+++ b/team_project/RELEASE_NOTES.md
@@ -1,0 +1,78 @@
+# Release Notes
+
+## v1.0.0 (2026-06-09)
+
+First stable release of the DAG Triage Assistant plugin for Apache Airflow 3.x.
+
+### Features
+
+- **Heuristic failure classifier** — regex-based classifier that categorizes task
+  failures into five categories: TRANSIENT, DATA_QUALITY, RESOURCE, CODE, and
+  EXTERNAL_DEPENDENCY, with ranked confidence scores. (#43)
+
+- **Log normalization layer** — parses raw Airflow task-instance logs into
+  structured `LogRecord` objects with timestamp, level, source, message, and
+  traceback extraction. (#44)
+
+- **Remediation knowledge base** — YAML-backed KB with eight Airflow failure
+  patterns providing actionable remediation steps and documentation links. (#45)
+
+- **Log tail capture** — extracts and caches the last N log lines from failed
+  task instances via the Airflow listener interface. (#31)
+
+- **Triage summary panel** — FastAPI sub-app mounted at `/triage-panel/` that
+  renders an interactive triage view on the Task Instance page with failure
+  category, confidence score, root-cause summary, and remediation steps. (#29, #33)
+
+- **Remediation checklist generator** — produces step-by-step remediation
+  checklists from failure categories for operator handoff. (#34)
+
+- **LLM provider abstraction** — pluggable `LLMProvider` interface with two
+  implementations: `OpenAIProvider` (hosted LLM) and `LocalRuleProvider`
+  (deterministic rules, zero external calls). Provider selection driven by
+  `[triage] llm_provider` in `airflow.cfg`. Automatic fallback to local rules
+  on provider failure. (#32)
+
+- **Docker Compose dev environment** — one-command `docker compose up` brings
+  up Airflow with the plugin pre-installed, a sample failing DAG for manual
+  triage testing, and source-mounted volumes for live reloading. (#28)
+
+- **Classifier test suite** — TDD-driven unit tests covering all five failure
+  categories, confidence ordering, and edge cases. (#35)
+
+### Documentation
+
+- Product problem framing document and PRFAQ index. (#1, #17)
+- Target user personas with upstream Airflow issue evidence. (#2, #19)
+- Architecture decision record for LLM provider selection. (#36)
+- Plugin architecture overview and sprint plan.
+
+### Installation
+
+```bash
+# From the fork:
+pip install "git+https://github.com/break-through-19/airflow.git#subdirectory=team_project"
+
+# With OpenAI support:
+pip install "dag-triage[openai] @ git+https://github.com/break-through-19/airflow.git#subdirectory=team_project"
+
+# Local editable install:
+cd team_project && pip install -e .
+```
+
+### Configuration
+
+```ini
+[triage]
+enabled = true
+log_tail_lines = 200
+llm_provider = local          # or "openai"
+# openai_api_key = sk-...     # required when llm_provider = openai
+```
+
+### Requirements
+
+- Apache Airflow >= 3.0
+- Python >= 3.10
+- PyYAML >= 6.0
+- FastAPI >= 0.100

--- a/team_project/pyproject.toml
+++ b/team_project/pyproject.toml
@@ -4,14 +4,37 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dag-triage"
-version = "0.1.0"
+version = "1.0.0"
 description = "AI-assisted DAG failure triage plugin for Apache Airflow"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["pyyaml>=6.0"]
+license = "Apache-2.0"
+keywords = ["airflow", "plugin", "triage", "observability", "dag"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: Apache Airflow",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: System :: Monitoring",
+]
+dependencies = [
+    "pyyaml>=6.0",
+    "fastapi>=0.100",
+]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pyyaml>=6.0"]
+openai = ["openai>=1.0"]
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.24",
+]
+
+[project.urls]
+Repository = "https://github.com/break-through-19/airflow"
+Issues = "https://github.com/break-through-19/airflow/issues"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -22,3 +45,6 @@ dag_triage = "dag_triage.plugin:DagTriagePlugin"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+dag_triage = ["../data/*.yaml"]

--- a/team_project/src/dag_triage/__init__.py
+++ b/team_project/src/dag_triage/__init__.py
@@ -7,4 +7,4 @@ from dag_triage.log_tail import LogTailResult, fetch_log_tail
 from dag_triage.log_tail_store import get_task_log_tail
 
 __all__ = ["LogTailResult", "fetch_log_tail", "get_task_log_tail"]
-__version__ = "0.1.0"
+__version__ = "1.0.0"


### PR DESCRIPTION
## Summary

- Bump package version from 0.1.0 to 1.0.0 across `pyproject.toml` and
  `__init__.py`.
- Add comprehensive release notes (`RELEASE_NOTES.md`) covering all merged
  features from tickets #28 through #45.
- Enrich `pyproject.toml` with classifiers, keywords, project URLs, an
  `[openai]` optional extra, and `package-data` for the remediation YAML.
- Add `MANIFEST.in` to ensure data files and docs are included in sdist builds.
- Both sdist and wheel build cleanly; `pip install -e .` confirms v1.0.0.

closes: #38

## What's included

| File | Change |
|---|---|
| `team_project/pyproject.toml` | Version → 1.0.0, classifiers, keywords, URLs, `[openai]` extra, package-data |
| `team_project/src/dag_triage/__init__.py` | `__version__` → `"1.0.0"` |
| `team_project/RELEASE_NOTES.md` | New — all merged features, install instructions, config reference |
| `team_project/MANIFEST.in` | New — ensures YAML data and release notes ship in sdist |

## Install verification

```bash
# From the fork:
pip install "git+https://github.com/break-through-19/airflow.git#subdirectory=team_project"

# With OpenAI support:
pip install "dag-triage[openai] @ git+https://github.com/break-through-19/airflow.git#subdirectory=team_project"

# Verify:
python -c "import dag_triage; print(dag_triage.__version__)"
# → 1.0.0